### PR TITLE
Save  wordlink translation without escaping

### DIFF
--- a/API/UploadWordLinkRecording.php
+++ b/API/UploadWordLinkRecording.php
@@ -19,7 +19,7 @@ if (!(
 
 $androidId = trim($_POST['PhoneId']);
 $term = trim($_POST['term']);
-$audioRecordingFilename = htmlspecialchars(trim($_POST['audioRecordingFilename']));
+$audioRecordingFilename = trim($_POST['audioRecordingFilename']);
 $textBackTranslation = trim($_POST['textBackTranslation']);
 
 // extract & validate audio recording file extension

--- a/API/UploadWordLinkRecording.php
+++ b/API/UploadWordLinkRecording.php
@@ -20,7 +20,7 @@ if (!(
 $androidId = trim($_POST['PhoneId']);
 $term = trim($_POST['term']);
 $audioRecordingFilename = htmlspecialchars(trim($_POST['audioRecordingFilename']));
-$textBackTranslation = htmlspecialchars(trim($_POST['textBackTranslation']));
+$textBackTranslation = trim($_POST['textBackTranslation']);
 
 // extract & validate audio recording file extension
 $audioRecordingFileExtension = pathinfo($audioRecordingFilename, PATHINFO_EXTENSION);

--- a/tests/integration/UploadWordLinkRecordingIntegrationTest.php
+++ b/tests/integration/UploadWordLinkRecordingIntegrationTest.php
@@ -16,7 +16,7 @@ class UploadWordLinkRecordingIntegrationTest extends BaseIntegrationTest
     const TERM_1 = "prayed";
     const TERM_2 = "pray";
     const TEXT_BACK_TRANSLATION_CONTENT = "Test data for text back translation";
-    const TEXT_BACK_TRANSLATION_CONTENT_UPDATED = "Updated test data for text back translation";
+    const TEXT_BACK_TRANSLATION_CONTENT_UPDATED = "<b>Updated test data for text back translation</b>";
     const RECORDING_FILE_EXTENSION = "m4a";
     const RECORDING_FILE_NAME_1 = "WordLinks 1." . self::RECORDING_FILE_EXTENSION;
     const RECORDING_FILE_NAME_2 = "WordLinks 2." . self::RECORDING_FILE_EXTENSION;


### PR DESCRIPTION
## Summary of change
* Removed html char escaping before persisting into DB
* Update unit test to assert expected behaviour


<img width="755" alt="Screenshot 2024-05-14 at 9 45 16 pm" src="https://github.com/techteam25/ROCC/assets/19812199/56986aca-f88f-47a8-9035-d0e4e035427d">
