### PR TITLE
Change matching term's color on the slide content if back translation…

### DIFF
--- a/client.php
+++ b/client.php
@@ -400,9 +400,9 @@ ksort($wordLinkTerms);
                     const link = document.createElement('a');
                     link.textContent = word;
 
-                    // display word link term in the slide using black color if there is back translation exits
+                    // display word link term in the slide using black color if there is a backtranslation exits
                     if (wordLinkTerms[word.toLowerCase()].hasWordLinkTranslations) {
-                        link.style.color = 'black';
+                        link.classList.add('hasWordLinkTranslations')
                     }
 
                     link.addEventListener('click', (event) => {

--- a/css/client.css
+++ b/css/client.css
@@ -644,6 +644,10 @@ input:checked + .slider:before {
     text-decoration: underline;
 }
 
+.transcripts #mainText a.hasWordLinkTranslations {
+	color: #000;
+}
+
 /* style for wordlinks */
 .wordlinks {
 	height: 323px;


### PR DESCRIPTION
### Summary of change
Change matched term font color to black if there is a  back translation exist in the database.

![image](https://github.com/techteam25/ROCC/assets/19812199/e2118a66-fa23-4d7d-b813-698998c2e31e)


![image](https://github.com/techteam25/ROCC/assets/19812199/74467b05-24f1-435c-82a1-5bd1adc1011f)


![image](https://github.com/techteam25/ROCC/assets/19812199/685b1889-5370-4e2e-9c14-ad136fc6aac8)
